### PR TITLE
postgresql option not working. debugging change

### DIFF
--- a/alcali/package/install.sls
+++ b/alcali/package/install.sls
@@ -13,7 +13,9 @@
       'Debian': ['default-libmysqlclient-dev', 'python3-dev'],
       'FreeBSD': ['curl'],
   }.get(grains.os_family) %}
-{% elif alcali.config.db_backend == 'postgresql' %}
+{% endif %}
+
+{% if alcali.config.db_backend == 'postgresql' %}
   {% set db_connector = 'psycopg2' %}
   {% set db_requirements = {
       'RedHat': ['libpq-devel', 'python3-devel'],


### PR DESCRIPTION
"Rendering SLS 'base:alcali.package.install' failed: Jinja variable 'db_requirements' is undefined" error from salt when db_backend was set to anything other than mysql